### PR TITLE
Fix bug in supporting reality

### DIFF
--- a/InvisibleMan-XRay/Models/Templates/Vless.cs
+++ b/InvisibleMan-XRay/Models/Templates/Vless.cs
@@ -55,6 +55,9 @@ namespace InvisibleManXRay.Models.Templates
                     sni = data.query["sni"] ?? "",
                     alpn = HttpUtility.UrlDecode(data.query["alpn"] ?? ""),
                     fingerprint = HttpUtility.UrlDecode(data.query["fp"] ?? ""),
+                    publicKey = HttpUtility.UrlDecode(data.query["pbk"] ?? ""),
+                    shortId = HttpUtility.UrlDecode(data.query["sid"] ?? ""),
+                    spiderX = HttpUtility.UrlDecode(data.query["spx"] ?? ""),
                 };
 
                 switch (adapter.streamNetwork)


### PR DESCRIPTION
Add `publicKey`, `shortId` and `spiderX` properties in the `vless` adapter.
Also, we upgrade the xray core in #67.
So, this features can close #48.