### PR TITLE
Fix the app crashing when there is no config

### DIFF
--- a/InvisibleMan-XRay/Windows/ServerWindow/ServerWindow.xaml.cs
+++ b/InvisibleMan-XRay/Windows/ServerWindow/ServerWindow.xaml.cs
@@ -416,13 +416,12 @@ namespace InvisibleManXRay
             
             void SelectConfig()
             {
-                if (configComponents.Count == 0)
-                    return;
-
-                if (index == configComponents.Count)
+                if (IsIndexOutOfRange())
                     return;
                 
                 configComponents[index].SetSelection(true);
+
+                bool IsIndexOutOfRange() => index >= configComponents.Count;
             } 
         }
     }


### PR DESCRIPTION
When a user adds some configs and then closes the app and removes the Configs folder, In the next run, the app was crashed.