### PR TITLE
Added a connection status indicator to the system tray icon

### DIFF
--- a/InvisibleMan-XRay/Factories/WindowFactory.cs
+++ b/InvisibleMan-XRay/Factories/WindowFactory.cs
@@ -30,6 +30,7 @@ namespace InvisibleManXRay.Factories
             UpdateHandler updateHandler = handlersManager.GetHandler<UpdateHandler>();
             BroadcastHandler broadcastHandler = handlersManager.GetHandler<BroadcastHandler>();
             SettingsHandler settingsHandler = handlersManager.GetHandler<SettingsHandler>();
+            NotifyHandler notifyHandler = handlersManager.GetHandler<NotifyHandler>();
             LinkHandler linkHandler = handlersManager.GetHandler<LinkHandler>();
 
             MainWindow mainWindow = new MainWindow();
@@ -37,6 +38,7 @@ namespace InvisibleManXRay.Factories
                 isNeedToShowPolicyWindow: IsNeedToShowPolicyWindow,
                 shouldStartHidden: ShouldStartHidden,
                 isNeedToAutoConnect: IsNeedToAutoConnect,
+                getMode: settingsHandler.UserSettings.GetMode,
                 getConfig: configHandler.GetCurrentConfig,
                 loadConfig: core.LoadConfig,
                 enableMode: core.EnableMode,
@@ -54,7 +56,8 @@ namespace InvisibleManXRay.Factories
                 onGenerateClientId: settingsHandler.GenerateClientId,
                 onGitHubClick: linkHandler.OpenGitHubRepositoryLink,
                 onBugReportingClick: linkHandler.OpenBugReportingLink,
-                onCustomLinkClick: linkHandler.OpenCustomLink
+                onCustomLinkClick: linkHandler.OpenCustomLink,
+                setIndicator: notifyHandler.SetIndicator
             );
             
             return mainWindow;

--- a/InvisibleMan-XRay/Handlers/NotifyHandler.cs
+++ b/InvisibleMan-XRay/Handlers/NotifyHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Windows.Forms;
 using System.Collections.Generic;
 
@@ -14,6 +15,7 @@ namespace InvisibleManXRay.Handlers
     public class NotifyHandler : Handler, IDisposable
     {
         private NotifyIcon notifyIcon;
+        private Icon baseIcon;
 
         private Func<Mode> getMode;
         private Action onOpenClick;
@@ -61,6 +63,7 @@ namespace InvisibleManXRay.Handlers
 
             notifyIcon = new NotifyIcon();
             notifyIcon.Icon = GetNotifyIcon();
+            baseIcon = notifyIcon.Icon;
             notifyIcon.Visible = true;
 
             HandleNotifyIconClick();
@@ -181,6 +184,45 @@ namespace InvisibleManXRay.Handlers
         private void CheckItem(ToolStripMenuItem item)
         {
             item.Checked = true;
+        }
+
+        public void SetIndicator(Mode? mode)
+        {
+            if (notifyIcon == null || baseIcon == null)
+                return;
+
+            if (mode == null)
+            {
+                notifyIcon.Icon = baseIcon;
+                return;
+            }
+
+            Color color = mode == Mode.TUN ? Color.Red : Color.Blue;
+            notifyIcon.Icon = CreateIndicatorIcon(color);
+        }
+        private Icon CreateIndicatorIcon(Color color)
+        {
+            using (Bitmap bmp = baseIcon.ToBitmap())
+            using (Graphics g = Graphics.FromImage(bmp))
+            using (Brush brush = new SolidBrush(color))
+            using (Pen outline = new Pen(Color.White, 1))
+            {
+                int size = bmp.Width / 3 + 2;
+                int x = bmp.Width - size - 1;
+                int y = bmp.Height - size - 1;
+
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+                g.FillEllipse(brush, x, y, size, size);
+                g.DrawEllipse(outline, x, y, size, size);
+
+                IntPtr hIcon = bmp.GetHicon();
+                Icon icon = (Icon)Icon.FromHandle(hIcon).Clone();
+                DestroyIcon(hIcon);
+                return icon;
+
+                [System.Runtime.InteropServices.DllImport("user32.dll")]
+                static extern bool DestroyIcon(IntPtr handle);
+            }
         }
 
         public void Dispose()

--- a/InvisibleMan-XRay/Windows/MainWindow/MainWindow.xaml.cs
+++ b/InvisibleMan-XRay/Windows/MainWindow/MainWindow.xaml.cs
@@ -27,6 +27,7 @@ namespace InvisibleManXRay
         private Func<UpdateWindow> openUpdateWindow;
         private Func<AboutWindow> openAboutWindow;
         private Func<PolicyWindow> openPolicyWindow;
+        private Func<Mode> getMode;
         private Action<string> onRunServer;
         private Action onCancelServer;
         private Action onStopServer;
@@ -35,6 +36,7 @@ namespace InvisibleManXRay
         private Action onGitHubClick;
         private Action onBugReportingClick;
         private Action<string> onCustomLinkClick;
+        private Action<Mode?> setIndicator;
 
         private BackgroundWorker runWorker;
         private BackgroundWorker updateWorker;
@@ -216,6 +218,7 @@ namespace InvisibleManXRay
             Func<bool> isNeedToShowPolicyWindow,
             Func<bool> shouldStartHidden,
             Func<bool> isNeedToAutoConnect,
+            Func<Mode> getMode,
             Func<Config> getConfig,
             Func<Status> loadConfig, 
             Func<Status> enableMode,
@@ -233,11 +236,13 @@ namespace InvisibleManXRay
             Action onGenerateClientId,
             Action onGitHubClick,
             Action onBugReportingClick,
-            Action<string> onCustomLinkClick)
+            Action<string> onCustomLinkClick,
+            Action<Mode?> setIndicator)
         {
             this.isNeedToShowPolicyWindow = isNeedToShowPolicyWindow;
             this.shouldStartHidden = shouldStartHidden;
             this.isNeedToAutoConnect = isNeedToAutoConnect;
+            this.getMode = getMode;
             this.getConfig = getConfig;
             this.loadConfig = loadConfig;
             this.checkForUpdate = checkForUpdate;
@@ -256,6 +261,7 @@ namespace InvisibleManXRay
             this.onGitHubClick = onGitHubClick;
             this.onBugReportingClick = onBugReportingClick;
             this.onCustomLinkClick = onCustomLinkClick;
+            this.setIndicator = setIndicator;
 
             UpdateUI();
         }
@@ -430,6 +436,8 @@ namespace InvisibleManXRay
             statusStop.Visibility = Visibility.Hidden;
             statusWaitForRun.Visibility = Visibility.Hidden;
 
+            setIndicator?.Invoke(getMode?.Invoke());
+
             buttonStop.Visibility = Visibility.Visible;
             buttonCancel.Visibility = Visibility.Hidden;
             buttonRun.Visibility = Visibility.Hidden;
@@ -441,6 +449,8 @@ namespace InvisibleManXRay
             statusRun.Visibility = Visibility.Hidden;
             statusWaitForRun.Visibility = Visibility.Hidden;
 
+            setIndicator?.Invoke(null);
+
             buttonRun.Visibility = Visibility.Visible;
             buttonCancel.Visibility = Visibility.Hidden;
             buttonStop.Visibility = Visibility.Hidden;
@@ -451,6 +461,8 @@ namespace InvisibleManXRay
             statusWaitForRun.Visibility = Visibility.Visible;
             statusStop.Visibility = Visibility.Hidden;
             statusRun.Visibility = Visibility.Hidden;
+
+            setIndicator?.Invoke(null);
 
             buttonCancel.Visibility = Visibility.Visible;
             buttonRun.Visibility = Visibility.Hidden;


### PR DESCRIPTION
Feature for #141 

Added a connection status indicator to the system tray icon, displaying the current proxy mode.

**Details:**

**Blue** indicator: active **Proxy** mode
![blue_indicator](https://github.com/user-attachments/assets/b4c22148-50dd-4954-a244-9d0275d13e1b)

**Red** indicator: active **TUN** mode
![red_indicator](https://github.com/user-attachments/assets/683361ec-94e4-48d6-9570-0ce78445ad87)

No indicator: no active connection
![no_indicator](https://github.com/user-attachments/assets/0be4b05e-80d0-44d0-ac61-e66a6fef1dba)

This visual cue helps users quickly assess the current proxy status without needing to open the full application UI.
The color scheme follows conventions used in alternative clients such as Nekoray and v2rayN, making the colors familiar and intuitive for users.

P.S. I noticed #195 solution after I had already made mine, but I decided to provide my solution anyway, maybe it will seem better.