### PR TITLE
Fix: Show window instead of error when launching second instance

### DIFF
--- a/InvisibleMan-XRay/InvisibleMan-XRay.csproj
+++ b/InvisibleMan-XRay/InvisibleMan-XRay.csproj
@@ -14,9 +14,11 @@
     <Nullable>enable</Nullable>
     <NoWarn>0108;8600;8601;8602;8603;8604;8618;8625;8629;8762</NoWarn>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>Assets/Icon.ico</ApplicationIcon>
     <PublishSingleFile>true</PublishSingleFile>
     <_SuppressWpfTrimError>true</_SuppressWpfTrimError>
+    <_SuppressWinFormsTrimError>true</_SuppressWinFormsTrimError>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>partial</TrimMode>
@@ -28,7 +30,6 @@
     <PackageReference Include="QRCoder.Xaml" Version="1.6.0" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
     <PackageReference Include="System.Management" Version="7.0.0" />
-    <PackageReference Include="System.Windows.Forms" />
   </ItemGroup>
 
   <ItemGroup>

--- a/InvisibleMan-XRay/Managers/AppManager.cs
+++ b/InvisibleMan-XRay/Managers/AppManager.cs
@@ -57,29 +57,12 @@ namespace InvisibleManXRay.Managers
                 if (IsThereAnyArg())
                     PipeManager.SignalOpenedApp(args);
                 else
-                    ShowAppAlreadyRunningMessageBox();
+                    PipeManager.SignalShowWindow();
                 
                 Environment.Exit(0);
             }
 
             bool IsThereAnyArg() => args.Length != 0;
-
-            void ShowAppAlreadyRunningMessageBox()
-            {
-                SettingsHandler settingsHandler = new SettingsHandler();
-                
-                LocalizationHandler localizationHandler = new LocalizationHandler();
-                localizationHandler.Setup(
-                    getCurrentLanguage: settingsHandler.UserSettings.GetLanguage
-                );
-
-                LocalizationService localizationService = new LocalizationService();
-                localizationService.Setup(
-                    getLocalizationResource: localizationHandler.GetLocalizationResource
-                );
-
-                MessageBox.Show(localizationService.GetTerm(Localization.APP_ALREADY_RUNNING));
-            }
         }
 
         private void SetApplicationCurrentDirectory()

--- a/InvisibleMan-XRay/Managers/Initializers/HandlersInitializer.cs
+++ b/InvisibleMan-XRay/Managers/Initializers/HandlersInitializer.cs
@@ -44,6 +44,7 @@ namespace InvisibleManXRay.Managers.Initializers
             SetupNotifyHandler();
             SetupDeepLinkHandler();
             SetupLocalizationHandler();
+            SetupPipeManager();
 
             void SetupProcessHandler()
             {
@@ -179,6 +180,11 @@ namespace InvisibleManXRay.Managers.Initializers
                 HandlersManager.GetHandler<LocalizationHandler>().Setup(
                     getCurrentLanguage: settingsHandler.UserSettings.GetLanguage
                 );
+            }
+
+            void SetupPipeManager()
+            {
+                PipeManager.OnShowWindow += OpenApplication;
             }
         }
         

--- a/InvisibleMan-XRay/Managers/PipeManager.cs
+++ b/InvisibleMan-XRay/Managers/PipeManager.cs
@@ -9,8 +9,10 @@ namespace InvisibleManXRay.Managers
     public static class PipeManager
     {
         private const string PIPE_NAME = "InvisibleManXRayPipe";
+        private const string SHOW_WINDOW_COMMAND = "--show-window";
 
         public static Action<string> OnReceiveArg = delegate{};
+        public static Action OnShowWindow = delegate{};
 
         public static void ListenForPipes()
         {
@@ -23,7 +25,10 @@ namespace InvisibleManXRay.Managers
                     StreamReader reader = new StreamReader(pipeServer);
                     string message = reader.ReadToEnd();
                     Application.Current.Dispatcher.BeginInvoke(new Action(delegate {
-                        OnReceiveArg.Invoke(message);
+                        if (message.Trim() == SHOW_WINDOW_COMMAND)
+                            OnShowWindow.Invoke();
+                        else
+                            OnReceiveArg.Invoke(message);
                     }));
                     
                     pipeServer.Close();
@@ -39,6 +44,17 @@ namespace InvisibleManXRay.Managers
 
             StreamWriter writer = new StreamWriter(pipeClient);
             writer.WriteLine(args[0]);
+            writer.Flush();
+            writer.Close();
+        }
+
+        public static void SignalShowWindow()
+        {
+            NamedPipeClientStream pipeClient = new NamedPipeClientStream(".", PIPE_NAME);
+            pipeClient.Connect();
+
+            StreamWriter writer = new StreamWriter(pipeClient);
+            writer.WriteLine(SHOW_WINDOW_COMMAND);
             writer.Flush();
             writer.Close();
         }


### PR DESCRIPTION
- Replace MessageBox with named pipe signal to show existing window
- Add --show-window command to PipeManager
- Subscribe OpenApplication() to OnShowWindow in HandlersInitializer
- Fix System.Windows.Forms package reference in csproj